### PR TITLE
fix(cli): remove warning about assets not included in diff (#4454)

### DIFF
--- a/packages/aws-cdk/lib/diff.ts
+++ b/packages/aws-cdk/lib/diff.ts
@@ -21,11 +21,6 @@ export function printStackDiff(
       context: number,
       stream?: FormatStream): number {
 
-  if (newTemplate.assets.length > 0) {
-    const issue = 'https://github.com/aws/aws-cdk/issues/395';
-    warning(`The ${newTemplate.name} stack uses assets, which are currently not accounted for in the diff output! See ${issue}`);
-  }
-
   const diff = cfnDiff.diffTemplate(oldTemplate, newTemplate.template);
 
   // filter out 'AWS::CDK::Metadata' resources from the template


### PR DESCRIPTION
Since source hash is now used to identify assets, if an asset changes,
the diff will show it (yey!).

Resolves #395



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

<!-- 
Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/aws/aws-cdk/blob/master/CONTRIBUTING.md
 -->
